### PR TITLE
Improve thread scheduling with dynamic row dispatch

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -13,7 +13,7 @@ TARGET = fractal
 SRCS = main.c
 
 # Use pkg-config to get the compiler flags for SDL2.
-CFLAGS = -Wall -O3 -march=native $(shell pkg-config --cflags sdl2) -pthread
+CFLAGS = -std=c11 -Wall -O3 -march=native $(shell pkg-config --cflags sdl2) -pthread
 
 # Use pkg-config for the base SDL2 library, and add others manually.
 # Note the addition of -pthread for multithreading.


### PR DESCRIPTION
## Summary
- Replace fixed row slices with dynamic row scheduling using an atomic counter for better CPU load balancing
- Add C11 atomics include and build flag to support the new scheduling logic

## Testing
- `make clean`
- `make`


------
https://chatgpt.com/codex/tasks/task_e_68a0ef95afc88326a0a1da361407ea56